### PR TITLE
Enable mobile project video autoplay

### DIFF
--- a/MOBILE_VIDEO_AUTOPLAY_FIX.md
+++ b/MOBILE_VIDEO_AUTOPLAY_FIX.md
@@ -1,0 +1,86 @@
+# Mobile Video Autoplay Fix
+
+## Problem
+Videos were not autoplaying on mobile devices (iOS Safari, Chrome Mobile, etc.) in the project details page.
+
+## Root Cause
+Mobile browsers have strict autoplay policies that require videos to be muted for autoplay to work. The original implementation had:
+- `muted={false}` which prevents autoplay on mobile
+- No mobile detection to handle different requirements
+- Missing mobile-specific attributes and fallbacks
+
+## Solution Implemented
+
+### 1. Added Mobile Detection
+- Imported and used `useIsMobile` hook to detect mobile devices
+- Applied mobile-specific video settings based on device type
+
+### 2. Updated Video Element Attributes
+```jsx
+<video
+  ref={videoRef}
+  className="absolute inset-0 w-full h-full object-cover"
+  onLoadedData={handleVideoLoad}
+  muted={isMobile ? true : false}  // Muted on mobile, unmuted on desktop
+  loop
+  playsInline
+  autoPlay
+  preload="auto"
+  webkit-playsinline="true"  // iOS Safari compatibility
+>
+```
+
+### 3. Enhanced Auto-play Logic
+- Mobile videos start muted to comply with autoplay policies
+- Desktop videos can start unmuted
+- Added fallback logic: if autoplay fails, retry with muted video
+- Proper error handling with console logging
+
+### 4. Updated YouTube Embed URLs
+- Dynamic mute parameter based on device: `&mute=${isMobile ? 1 : 0}`
+- Ensures YouTube videos also respect mobile autoplay requirements
+
+### 5. Added User Interaction Handling
+- Mobile users can tap the video to unmute after autoplay starts
+- YouTube videos can be unmuted on user interaction
+- Graceful fallback if unmuting fails
+
+### 6. Mobile UX Enhancement
+- Added "Tap to unmute" indicator for mobile users
+- Appears when video is playing but muted on mobile
+- Clear visual feedback for user interaction
+
+## Technical Details
+
+### Mobile Autoplay Requirements
+According to mobile browser policies:
+- **iOS Safari**: Requires `muted`, `playsInline`, and `autoplay` attributes
+- **Chrome Mobile**: Requires `muted` attribute for autoplay
+- **User interaction**: Can override mute requirements after initial autoplay
+
+### Implementation Benefits
+1. **Cross-platform compatibility**: Works on both mobile and desktop
+2. **Progressive enhancement**: Starts muted on mobile, allows unmuting on interaction
+3. **Better UX**: Clear indicators and smooth transitions
+4. **Compliance**: Follows mobile browser autoplay policies
+
+### Files Modified
+- `src/components/ProjectDetailPage.tsx`: Main video component logic
+- Added mobile detection and conditional rendering
+- Enhanced error handling and user interaction
+
+## Testing Recommendations
+1. Test on iOS Safari (iPhone/iPad)
+2. Test on Chrome Mobile (Android)
+3. Test on desktop browsers (should work as before)
+4. Verify tap-to-unmute functionality on mobile
+5. Check YouTube video autoplay on both mobile and desktop
+
+## Browser Support
+- ✅ iOS Safari 10+ (with `playsinline` and `muted`)
+- ✅ Chrome Mobile 54+ (with `muted`)
+- ✅ Firefox Mobile 49+
+- ✅ Desktop browsers (all modern browsers)
+- ⚠️ Some older mobile browsers may still require user interaction
+
+The fix ensures videos autoplay reliably across all platforms while providing a good user experience with the ability to unmute on mobile devices through user interaction.


### PR DESCRIPTION
Enable video autoplay on mobile devices by complying with browser mute policies and adding user interaction to unmute.

Mobile browsers (e.g., iOS Safari, Chrome Mobile) require videos to be muted for autoplay to function. The previous implementation did not account for this, causing videos to fail autoplay on mobile. This PR introduces mobile detection, mutes videos by default on mobile, and provides a 'tap to unmute' interaction.